### PR TITLE
Fix removing folder with unicode filenames

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -80,7 +80,7 @@ def clearStorage(userStorageDirectory):
             shutil.move(saved, saved_temp)
             saved_bool = True
 
-        shutil.rmtree(userStorageDirectory, ignore_errors=True)
+        shutil.rmtree(userStorageDirectory.encode('utf-8'), ignore_errors=True)
         xbmcvfs.mkdir(userStorageDirectory)
 
         if torrents_bool:


### PR DESCRIPTION
Can't clear storage in case there are files/folders with unicode in name
https://bugs.python.org/issue3616