### PR TITLE
Use zlib instead of gzip

### DIFF
--- a/Anteoloader.py
+++ b/Anteoloader.py
@@ -22,7 +22,7 @@ import urllib2
 import hashlib
 import re
 from StringIO import StringIO
-import gzip
+import zlib
 
 import xbmc
 import xbmcgui
@@ -205,8 +205,8 @@ class AnteoLoader:
                     result = urllib2.urlopen(request)
                     if result.info().get('Content-Encoding') == 'gzip':
                         buf = StringIO(result.read())
-                        f = gzip.GzipFile(fileobj=buf)
-                        content = f.read()
+                        decomp = zlib.decompressobj(16 + zlib.MAX_WBITS)
+                        content = decomp.decompress(buf.getvalue())
                     else:
                         content = result.read()
 

--- a/Libtorrent.py
+++ b/Libtorrent.py
@@ -24,7 +24,7 @@ import urllib2
 import hashlib
 import re
 from StringIO import StringIO
-import gzip
+import zlib
 import sys
 
 import xbmc
@@ -108,8 +108,8 @@ class Libtorrent:
                     result = urllib2.urlopen(request)
                     if result.info().get('Content-Encoding') == 'gzip':
                         buf = StringIO(result.read())
-                        f = gzip.GzipFile(fileobj=buf)
-                        content = f.read()
+                        decomp = zlib.decompressobj(16 + zlib.MAX_WBITS)
+                        content = decomp.decompress(buf.getvalue())
                     else:
                         content = result.read()
 
@@ -428,7 +428,7 @@ class Libtorrent:
                        #'storage_mode': self.lt.storage_mode_t(1),
                        'paused': False,
                        #'auto_managed': False,
-                       'duplicate_is_error': False
+                       #'duplicate_is_error': True
                       }
         if self.save_resume_data:
             log('loading resume data')


### PR DESCRIPTION
The reason to make this change is that I had problems with some URL's and I saw that the problem whas the Gunzip.

I saw that the "gzip" http content is the same that we can found in this stackoverflow post: http://stackoverflow.com/a/3947241/1344260

And it fails too, here you  have my test/problem: http://pastebin.com/3rvmCEkU

It do a IOError: CRC check failed 0xac557afc != 0x2338b236L
and torrenter fails.

After that, I read this message and test the solution: http://stackoverflow.com/a/13692010/1344260

And its working. So I changed the code.

PD: I don't know what I changed in the file that git shows all the file as modified (I used "browser upload" to upload this 2 files) but you can see in Anteoloader.py:208 and Libtorrent.py:111 the really modified lines.