### PR TITLE
Fix magnetToTorrent

### DIFF
--- a/SkorbaLoader.py
+++ b/SkorbaLoader.py
@@ -188,10 +188,9 @@ class SkorbaLoader:
         if torrentInfo:
             try:
                 torrentFile = self.lt.create_torrent(torrentInfo)
-                baseName = os.path.basename(self.storageDirectory + os.sep + torrentInfo.files()[0].path)
                 if not xbmcvfs.exists(self.torrentFilesPath):
                     xbmcvfs.mkdirs(self.torrentFilesPath)
-                self.torrentFile = self.torrentFilesPath + self.md5(baseName) + '.torrent'
+                self.torrentFile = self.torrentFilesPath + self.md5(magnet) + '.torrent'
                 torentFileHandler = xbmcvfs.File(self.torrentFile, "w+b")
                 torentFileHandler.write(self.lt.bencode(torrentFile.generate()))
                 torentFileHandler.close()


### PR DESCRIPTION
magnetToTorrent was broken because torrentFile.files is not indexable (but is iterable).
The only reason to use files[0] is to generate a "baseName" that is finally used to do self.md5(baseName) for the torrent file.

I can iterate to the first element (to emulate files[0]) and get the name, but I think that is useless.

We can remove this and use the magnet. I think that the best will be use the magnet ID information from the magnet link, not all the magnet, to remove optional arguments, but his is acceptable as a fast fix, and much better that the initial approach that can colisitionate with other files that have the same initial file (imagine a README.txt!!!!)