### PR TITLE
Kodi crash on launching play a file inside .torrent file

### DIFF
--- a/Core.py
+++ b/Core.py
@@ -1379,6 +1379,9 @@ class Core:
         if not url:
             action = xbmcgui.Dialog()
             url = action.browse(1, self.localize('Choose .torrent in video library'), 'video', '.torrent')
+            torrent = Downloader.Torrent(self.userStorageDirectory, torrentFilesDirectory=self.torrentFilesDirectory)
+            self.__settings__.setSetting("lastTorrent", torrent.saveTorrent(url))
+            self.__settings__.setSetting("lastTorrentUrl", url)
             if url:
                 xbmc.executebuiltin(
                                 'XBMC.ActivateWindow(%s)' % 'Videos,plugin://plugin.video.torrenter/?action=%s&url=%s'


### PR DESCRIPTION
Hello, please consider these changes to be merged into the repository.
I propose it because it solved my problem which I had a few times before and constantly emerged last few days till that fix.
The problem is - when I open torrenter -> .torrent player -> a_file.torrent -> actual movie, kodi restarts. In onther cases, it plays, but not the movie I've just chosen, but instead, another one, which is in "lastTorrent" config variable. Honestly, it's hard to say how could it work before, but looking through the code it seems that it shouldn't work properly without these changes, but you better know, please review the process of launching a video file.
From what I see, the logic is - 
1) Torrenter opened
[Torrenter v.2.5.4]: SYS ARGV: ['plugin://plugin.video.torrenter/', '10', '']
2) ".torrent Player" has choosen
### [Torrenter v.2.5.4]: SYS ARGV: ['plugin://plugin.video.torrenter/', '11', '?action=torrentPlayer&url']
3) Due to the fact, that "url" is empty, 
plugin://plugin.video.torrenter/?action=torrentPlayer&url
a .torrent file choose dialog appears
https://github.com/DiMartinoXBMC/plugin.video.torrenter/blob/master/Core.py#L1381
4)  torrenter launches Video choose window(MyVideoNav.xml) and we choose a movie or an episode among few others inside .torrent file.
5) when we choose an episode, old torrenter instance closes, and the new one launches
### [Torrenter v.2.5.4]: SYS ARGV: ['plugin://plugin.video.torrenter/', '-1', '?action=playTorrent&url=13&thumbnail=DefaultVideo.png']
it wants to call playTorrent function with "virtual" file index url=13 in a .torrent file which it takes from the settings
https://github.com/DiMartinoXBMC/plugin.video.torrenter/blob/master/Core.py#L1415
https://github.com/DiMartinoXBMC/plugin.video.torrenter/blob/master/Inposloader.py#L356
https://github.com/inpos/script.module.pyrrent2http/blob/master/lib/pyrrent2http/engine.py#L220
and so on..
here
https://github.com/DiMartinoXBMC/plugin.video.torrenter/blob/master/Core.py#L1433
it puts in torrentUrl the value from settings file which hasn't been updated after we choose .torrent file and it passes an episode_inside_torrent index within params.

After I added these lines to update config file upon .torrent file selection, the problem is gone. I also tested a few time with different torrent files as well as with magnet links, so far so good.

I'm running kodi on osmc installed on RPi2. Tried to clone this repository directly to my RPi, the problem persists.

you may find the log here:
https://gist.github.com/kolosovski/f18fc3f49c5f83db8c751fe6a5b02fce
the file intended to play is "/media/USB-FLASH/torrents/Everybody_Hates_Chris_3.torrent"
but instead torrenter plays
[pyrrent2http] INFO: Downloading torrent: The Secret Life of Pets (720p HD).m4v