### PR TITLE
Autopause on play fix

### DIFF
--- a/Inposloader.py
+++ b/Inposloader.py
@@ -541,7 +541,7 @@ class InposPlayer(xbmc.Player):
 
                     self.iterator = int(file_status.progress * 100)
 
-                    if pause and self.__settings__.getSetting("pause_onplay") == 'true':
+                    if pause and (self.__settings__.getSetting("pause_onplay") == 'true') and (self.getTime() > 0):
                         pause = False
                         xbmc.Player().pause()
                     xbmc.sleep(1000)


### PR DESCRIPTION
I faced another issue with pause_onplay option. For some reasons it doesn't pause playback right after start. This reproduces on relatively large video files(about 3GB) - it doesn't pause the playback, but works well if I open a small 700MB episode - in this case playback pauses somewhat after 2 seconds.
After some investigation I figured out that the xbmc.Play() class doesn't provide any method to check if we playing or the playback is paused. The isPlaying() method always returns 1 after playback was launched, no matter that it's on pause or not. So I added additional check "(self.getTime() > 0)" for assigning "pause = False" only if the playback is definitely started. Otherwise on the very first iteration "xbmc.Player().pause()" may unsuccessfully pause the playback maybe because it doesn't completely initiated yet and due to pause == False it will not try to pause again
Also I've reproduced the issue on both RPi based and windows based kodi installations. Please review and consider to merge these changes.