### PR TITLE
Fix handling special:// paths

### DIFF
--- a/Core.py
+++ b/Core.py
@@ -30,7 +30,7 @@ class Core:
     __plugin__ = sys.modules["__main__"].__plugin__
     __settings__ = sys.modules["__main__"].__settings__
     ROOT = sys.modules["__main__"].__root__
-    userStorageDirectory = localize_path(__settings__.getSetting("storage"))#file_encode(__settings__.getSetting("storage"))
+    userStorageDirectory = localize_path(xbmc.translatePath(__settings__.getSetting("storage")))#file_encode(__settings__.getSetting("storage"))
     torrentFilesDirectory = 'torrents'
     debug = __settings__.getSetting('debug') == 'true'
     torrent_player = __settings__.getSetting("torrent_player")
@@ -1455,9 +1455,9 @@ class Core:
             #xbmc.executebuiltin('xbmc.RunPlugin("plugin://plugin.video.yatp/?action=play&torrent=%s&file_index=%s")' % (urllib.quote_plus(torrentUrl), params['url']))
         elif self.torrent_player == '1':
             __ASsettings__ = xbmcaddon.Addon(id='script.module.torrent.ts')
-            folder=__ASsettings__.getSetting("folder")
+            folder=__ASsettings__.getSetting("path")
             save=__ASsettings__.getSetting("save")
-            __ASsettings__.setSetting("folder", self.__settings__.getSetting("storage"))
+            __ASsettings__.setSetting("path", xbmc.translatePath(self.__settings__.getSetting("storage")))
             __ASsettings__.setSetting("save", self.__settings__.getSetting("keep_files"))
             xbmc.sleep(1000)
             torrent = Downloader.Torrent(self.userStorageDirectory, torrentUrl, self.torrentFilesDirectory)
@@ -1468,7 +1468,7 @@ class Core:
             label = unquote(get("label"), os.path.basename(path))
             torrent.play_url_ind(int(ind), label, icon)
             torrent.__exit__()
-            __ASsettings__.setSetting("folder", folder)
+            __ASsettings__.setSetting("path", folder)
             __ASsettings__.setSetting("save", save)
 
     def saveUrlTorrent(self, url):

--- a/functions.py
+++ b/functions.py
@@ -43,7 +43,7 @@ except:
 __settings__ = xbmcaddon.Addon(id='plugin.video.torrenter')
 __language__ = __settings__.getLocalizedString
 ROOT = __settings__.getAddonInfo('path')  # .decode('utf-8').encode(sys.getfilesystemencoding())
-userStorageDirectory = __settings__.getSetting("storage")
+userStorageDirectory = xbmc.translatePath(__settings__.getSetting("storage"))
 torrentFilesDirectory = 'torrents'
 USERAGENT = "Mozilla/5.0 (Windows NT 6.1; rv:5.0) Gecko/20100101 Firefox/5.0"
 __addonpath__ = __settings__.getAddonInfo('path')


### PR DESCRIPTION
Convert special:// path to absolute ones for file operations to work. Fix reference to "path" setting for AceStream