### PR TITLE
Close dialogs before recursive call

### DIFF
--- a/Core.py
+++ b/Core.py
@@ -1397,6 +1397,7 @@ class Core:
             self.__settings__.setSetting("lastTorrent", torrent.saveTorrent(url))
             self.__settings__.setSetting("lastTorrentUrl", url)
             if url:
+                xbmc.executebuiltin("Dialog.Close(all,true)")
                 xbmc.executebuiltin(
                                 'XBMC.ActivateWindow(%s)' % 'Videos,plugin://plugin.video.torrenter/?action=%s&url=%s'
                 % ('torrentPlayer', url))


### PR DESCRIPTION
Here is how it would fail otherwise with local torrent:
10:31:40.149 T:6140948480  NOTICE: ### [Torrenter v.2.5.5ja]: Torrenter v.2.5.5ja
10:31:40.184 T:6140948480  NOTICE: ### [Torrenter v.2.5.5ja]: SYS ARGV: ['plugin://plugin.video.torrenter/', '3', '?action=torrentPlayer&url']
10:31:40.441 T:6143242240   DEBUG: ------ Window Init (DialogBusy.xml) ------
10:31:40.441 T:6143242240   DEBUG: Window DialogBusy.xml was already loaded
10:31:40.441 T:6143242240   DEBUG: Alloc resources: 0.09ms
10:31:40.443 T:6143242240    INFO: Loading skin file: FileBrowser.xml, load type: KEEP_IN_MEMORY
10:31:40.465 T:6143242240   DEBUG: Load FileBrowser.xml: 21.30ms
10:31:40.466 T:6143242240   DEBUG: Alloc resources: 22.84ms  (21.71 ms skin load)
10:31:40.483 T:6143242240   DEBUG: ------ Window Init (FileBrowser.xml) ------
10:31:40.484 T:6143242240   DEBUG: Window FileBrowser.xml was already loaded
10:31:40.484 T:6143242240   DEBUG: Alloc resources: 0.02ms
10:31:48.076 T:6143242240   DEBUG: ------ Window Deinit (FileBrowser.xml) ------
10:31:48.112 T:6140948480  NOTICE: ### [Torrenter v.2.5.5ja]: Imported TSengine from ASCore
10:31:48.119 T:6140948480   DEBUG: DialogProgress::Open called
10:31:48.119 T:6140948480   DEBUG: ------ Window Init (DialogConfirm.xml) ------
10:31:48.120 T:6140948480   DEBUG: Window DialogConfirm.xml was already loaded
10:31:48.120 T:6140948480   DEBUG: Alloc resources: 1.00ms
10:31:48.126 T:6140948480   DEBUG: NSUSerDefaults: compressed /userdata/addon_data/script.module.torrent.ts/settings.xml from 643 to 288
10:31:48.133 T:6140948480   DEBUG: Previous line repeats 1 times.
10:31:48.133 T:6140948480  NOTICE: ### [Torrenter v.2.5.5ja]: xbmcvfs.File for smb://srv/Main/Kodi/Torrents/293.torrent
10:31:48.136 T:6140948480   DEBUG: CSMBFile::Open - opened smb://srv/Main/Kodi/Torrents/293.torrent, fd=10000
10:31:48.145 T:6140948480   DEBUG: CSMBFile::Close closing fd 10000
10:31:49.604 T:6140948480   DEBUG: NSUSerDefaults: compressed /userdata/addon_data/plugin.video.torrenter/settings.xml from 4555 to 1068
10:31:49.643 T:6143242240   DEBUG: Previous line repeats 3 times.
10:31:49.643 T:6143242240   DEBUG: Activating window ID: 10025
10:31:49.643 T:6143242240    INFO: Activate of window '10025' refused because there are active modal dialogs
10:31:49.893 T:6143242240   DEBUG: ------ Window Deinit (DialogConfirm.xml) ------
10:32:16.976 T:6148403200   DEBUG: Thread JobWorker 0 terminating (autodelete)